### PR TITLE
Undefined name: B_img --> ref_img

### DIFF
--- a/data/fewshot_face_dataset.py
+++ b/data/fewshot_face_dataset.py
@@ -114,7 +114,7 @@ class FewshotFaceDataset(BaseDataset):
             crop_coords = self.get_crop_coords(points)   
             if not opt.isTrain: 
                 if self.fix_crop_pos: self.crop_coords = crop_coords
-                else: self.crop_size = B_img.size
+                else: self.crop_size = ref_img.size
             self.bw = max(1, (crop_coords[1]-crop_coords[0]) // 256)
 
             # get keypoints for all frames


### PR DESCRIPTION
__B_img__ is an _undefined name_ in this context which may raise NameError at runtime.